### PR TITLE
fake termcolor's colored() function if there is no termcolor

### DIFF
--- a/src/acm/core.py
+++ b/src/acm/core.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 ## Package acm.core
 ## Core objects for Apache Cluster Manager project
-from termcolor import colored
+try:
+  from termcolor import colored
+except ImportError:
+  def colored(s, *args, **kwargs):
+    return s
 from functional import curry
 from urllib2 import Request,urlopen
 import re


### PR DESCRIPTION
this is different from dbalagansky@fd40229edf4535d617f3dd0fb81cd69d3528d8f3, as I prefer not to have colors at all, instead of hardcoding ansi codes noone wants to remember.
